### PR TITLE
Fix typo in everest.yaml

### DIFF
--- a/everest.yaml
+++ b/everest.yaml
@@ -1,6 +1,6 @@
 - Name: SpringCollab2020
   Version: 1.0.0
-  DLL: bin/Debug/net45/SpringCollab2020.dll
+  DLL: bin/Debug/net452/SpringCollab2020.dll
   Dependencies:
     - Name: Everest
       Version: 1.1311.0


### PR DESCRIPTION
DLL location listed as /net45/ instead of /net452/